### PR TITLE
Return empty string when there was no output caught from composer update

### DIFF
--- a/src/ComposerUpdater.php
+++ b/src/ComposerUpdater.php
@@ -16,6 +16,6 @@ class ComposerUpdater
             $output = 'Shell exec didn\'t finish correctly.';
         }
 
-        return $output;
+        return $output ?? '';
     }
 }


### PR DESCRIPTION
Bug message (when the tool performs composer update):
MartinsR\ComposerConstraintUpdater\ComposerUpdater::updateComposer(): Return value must be of type string, null returned

For some reason sometimes `composer update` output from shell_exec() returns null, despite the execution went successful. And the process terminates. And at the same time the output from the command was in the terminal. One theory is that composer somehow smartly passes it's output to the terminal from where it was called, rather than to stdout, and then shell_exec() return something only if composer throws some errors or warnings to stderr. But if the process finishes without any errors/warnings then the tool fails.