### PR TITLE
Deprecation fixes for PHP 8.4

### DIFF
--- a/src/MajorConstraintUpdaterCommand.php
+++ b/src/MajorConstraintUpdaterCommand.php
@@ -14,7 +14,7 @@ class MajorConstraintUpdaterCommand extends BaseCommand
 {
     private ComposerUpdater $composerUpdater;
 
-    public function __construct(string $name = null, ?ComposerUpdater $composerUpdater = null)
+    public function __construct(?string $name = null, ?ComposerUpdater $composerUpdater = null)
     {
         $this->composerUpdater = $composerUpdater ?? new ComposerUpdater();
         parent::__construct($name);

--- a/src/MinorConstraintUpdaterCommand.php
+++ b/src/MinorConstraintUpdaterCommand.php
@@ -14,7 +14,7 @@ class MinorConstraintUpdaterCommand extends BaseCommand
 {
     private ComposerUpdater $composerUpdater;
 
-    public function __construct(string $name = null, ?ComposerUpdater $composerUpdater = null)
+    public function __construct(?string $name = null, ?ComposerUpdater $composerUpdater = null)
     {
         $this->composerUpdater = $composerUpdater ?? new ComposerUpdater();
         parent::__construct($name);


### PR DESCRIPTION
Fixes for PHP 8.4 related "Implicitly marking parameter $name as nullable is deprecated" deprecation notice.